### PR TITLE
Increase tests coverage for blog-roll and tag-roll pages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
             'pytest-splinter',
             'pytest-timeout',
             'webtest',
+            'factory_boy',
         ],
         # Dependencies to make releases
         'dev': [
@@ -81,7 +82,7 @@ setup(
             'sphinx-autodoc-typehints',
             'sphinx_rtd_theme',
             'sphinxcontrib-zopeext',
-            'zest.releaser[recommended]'
+            'zest.releaser[recommended]',
         ],
     },
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ deps =
     codecov
     flake8
     isort
+    factory_boy
 
 commands =
     py.test --timeout=2400 websauna/blog {posargs}

--- a/websauna/blog/templates/blog/tag_roll.html
+++ b/websauna/blog/templates/blog/tag_roll.html
@@ -7,7 +7,7 @@
   {% include "blog/admin_panel.html" %}
 
   <h1 id="heading-tag">Posts tagged {{ tag }}</h1>
-  {% with posts=tagged_posts %}
+  {% with posts=batch.items %}
     {% include "blog/blog_roll_content.html" %}
   {% endwith %}
 

--- a/websauna/blog/tests/conftest.py
+++ b/websauna/blog/tests/conftest.py
@@ -1,0 +1,46 @@
+"""``websauna.blog`` top level fixtures."""
+import pytest
+
+
+@pytest.fixture()
+def fakefactory(dbsession):
+    """Fakefactory fixture for creating dummy content.
+
+    Fixture attaches sqlachemy session to ``factory_boy`` content factories
+    via ``DBSessionProxy`` and provides module with factories as a dependency
+    injection for tests.
+
+    note::
+
+        Using `recommended recipe on attaching session to factories`_
+        with usage of ``scoped_session`` will result in having different
+        sessions for tests and factories, that is why session is shared
+        to factories via proxy, which is set up by this fixture.
+
+
+    warning:: the fixture is not thread safe
+
+    .. _recommended recipe on attaching session to factories: https://factoryboy.readthedocs.io/en/latest/orms.html#managing-sessions
+
+    """
+
+    from websauna.blog.tests import fakefactory
+    fakefactory.DB_SESSION.session = dbsession
+    try:
+        yield fakefactory
+    finally:
+        fakefactory.DB_SESSION.session = None
+
+
+@pytest.fixture()
+def login_user(web_server, browser):
+    """Fixture that return function to log user in"""
+
+    def login_user(user):
+        browser.visit(web_server + "/login")
+        browser.fill("username", user.email)
+        browser.fill("password", "qwerty")  # XXX: hardcoded password
+        browser.find_by_name("login_email").click()
+        assert browser.is_element_present_by_css("#nav-logout")
+
+    yield login_user

--- a/websauna/blog/tests/fakefactory.py
+++ b/websauna/blog/tests/fakefactory.py
@@ -1,0 +1,125 @@
+"""Factories for creating dummy content objects."""
+
+# Standard Library
+from uuid import uuid4
+
+# Pyramid
+from pyramid.threadlocal import get_current_registry
+
+import factory
+
+# Websauna
+from websauna.blog import models
+from websauna.system.user import models as ws_models
+from websauna.system.user.interfaces import IPasswordHasher
+from websauna.utils.time import now
+
+
+class DBSessionProxy:
+    """Proxy for attaching the right sqlachemy's session to the fake-factories.
+
+    ``factory_boy`` requires sqlachemy's session to be defined on fake-factories
+    at declaration stage, but ``websauna`` creates the session at the late
+    configuration stage and newer exposes it as global variable. This proxy
+    allows the session to be attached to the fake-factories by tests or fixtures.
+    """
+    session = None
+
+    def __getattr__(self, attr):
+        return getattr(self.session, attr)
+
+
+DB_SESSION = DBSessionProxy()
+
+
+def hash_password(password: str):
+    """Transform password into hash"""
+
+    registry = get_current_registry()
+    hasher = registry.getUtility(IPasswordHasher)
+    hashed = hasher.hash_password(password)
+    return hashed
+
+
+def ensure_admin_group_returned():
+    """Return admin group. If the group doesn't exist then create it."""
+
+    admin_group = (
+        DB_SESSION.query(ws_models.Group).filter_by(name=ws_models.Group.DEFAULT_ADMIN_GROUP_NAME).first()
+    )
+    if admin_group is None:
+        admin_group = GroupFactory(name=ws_models.Group.DEFAULT_ADMIN_GROUP_NAME)
+    return admin_group
+
+
+class BaseFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """Base factory for working session."""
+
+    class Meta:
+        sqlalchemy_session = DB_SESSION
+        force_flush = True
+        abstract = True
+
+
+class GroupFactory(BaseFactory):
+    """Factory for creating dummy Groups."""
+
+    name = factory.Faker("slug")
+
+    class Meta:
+        model = ws_models.Group
+
+
+class UserFactory(BaseFactory):
+    """Factory for creating dummy Users."""
+
+    username = factory.Faker("user_name")
+    email = factory.Faker("email")
+    hashed_password = factory.LazyAttribute(lambda obj: hash_password(obj.password))
+    activated_at = factory.LazyAttribute(lambda obj: now())
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        """Ensure that newly created user can log in."""
+        user = super()._create(model_class, *args, **kwargs)
+        assert user.can_login()
+        return user
+
+    class Meta:
+        model = ws_models.User
+        exclude = ("password",)
+
+    class Params:
+        password = "qwerty"
+
+        #: Trait for creating admin users
+        admin = factory.Trait(
+            groups=factory.LazyAttribute(lambda obj: [ensure_admin_group_returned()]),
+        )
+
+
+class PostFactory(BaseFactory):
+    """Factory for creating dummy Posts."""
+
+    title = factory.Faker("catch_phrase")
+    excerpt = factory.Faker("sentence")
+    body = factory.Faker("text", max_nb_chars=2000)
+    author = factory.Faker('name')
+    slug = factory.LazyAttribute(lambda obj: uuid4().hex)
+    created_at = factory.Faker('date_this_decade')
+    tags = factory.Sequence(lambda n: 'tag-%d' % n)
+
+    class Meta:
+        model = models.Post
+
+    class Params:
+
+        #: Trait for creating public posts
+        public = factory.Trait(
+            published_at=factory.LazyAttribute(lambda obj: now())
+        )
+
+        #: Trait for creating private posts
+        private = factory.Trait(
+            published_at=None
+        )

--- a/websauna/blog/tests/functional/test_blog_roll.py
+++ b/websauna/blog/tests/functional/test_blog_roll.py
@@ -1,57 +1,130 @@
-"""Functional tests."""
+"""Blog roll page functional tests."""
+
+# Standard Library
+import random
+
+# Pyramid
+import transaction
 
 # SQLAlchemy
 from sqlalchemy.orm.session import Session
 
+import arrow
 from splinter.driver import DriverAPI
 
+# Websauna
+from websauna.blog.tests.testing import pagination_test
 
-def test_empty_blog(web_server: str, browser: DriverAPI, dbsession: Session):
+
+def test_empty_blog(web_server: str, dbsession: Session, browser: DriverAPI):
     """We can render empty blog."""
 
-    # Direct Splinter browser to the website
-    b = browser
-    b.visit(web_server + "/blog/")
-
+    browser.visit(web_server + "/blog/")
     # After login we see a profile link to our profile
-    assert b.is_element_visible_by_css("#blog-no-posts")
+    assert browser.is_element_visible_by_css("#blog-no-posts")
 
 
-def test_no_unpublished_in_blog_roll(web_server: str, browser: DriverAPI, dbsession: Session, unpublished_post_id):
-    """Visitors should not see unpublished posts in blog roll."""
+def test_no_unpublished_posts_in_blog_roll(
+    web_server: str, browser: DriverAPI, dbsession: Session, fakefactory
+):
+    """Visitors sees no unpublished posts in blog-roll."""
 
-    # Direct Splinter browser to the website
-    b = browser
-    b.visit(web_server + "/blog/")
+    # creating a private post, it should not be listed in roll for a visitor
+    with transaction.manager:
+        fakefactory.PostFactory(private=True)
 
-    # After login we see a profile link to our profile
-    assert b.is_element_visible_by_css("#blog-no-posts")
+    # after navigating to blog-roll there are no posts displayed
+    browser.visit(web_server + "/blog/")
+    assert browser.is_element_visible_by_css("#blog-no-posts")
 
 
-def test_published_excerpt(web_server: str, browser: DriverAPI, dbsession: Session, published_post_id):
+def test_published_posts_in_blog_roll(web_server: str, browser: DriverAPI, dbsession: Session, fakefactory):
     """When posts are published they become visible in blog roll."""
 
-    # Direct Splinter browser to the website
-    b = browser
-    b.visit(web_server + "/blog/")
+    # creating a published post
+    with transaction.manager:
+        post = fakefactory.PostFactory(public=True)
+        dbsession.expunge_all()
 
-    # After login we see a profile link to our profile
-    assert b.is_element_visible_by_css(".excerpt")
+    # after navigating to blog-roll the post are displayed
+    browser.visit(web_server + "/blog/")
+    assert len(browser.find_by_css("div.post")) == 1
+    post_line = browser.find_by_css("div.post")[0]
+    assert post_line.find_by_css('h2').text == post.title
+    assert post_line.find_by_css('.excerpt').text == post.excerpt
+    assert (
+        post_line.find_by_css('.text-muted').text ==
+        'By {} just now. Tagged under {}.'.format(post.author, post.tags)
+    )
+
+    # user can navigate to post by clicking on its title on blog-roll page
+    post_line.find_by_css('.post-link').click()
+    assert browser.find_by_css("h1#heading-post").text == post.title
 
 
-def test_blog_pagination(web_server: str, browser: DriverAPI, dbsession: Session, publish_posts):
+def test_posts_are_listed_in_publication_order(
+    web_server: str, browser: DriverAPI, dbsession: Session, fakefactory
+):
+    """Post are listed in publication order on blog-roll."""
+
+    dates_span = arrow.Arrow.range("hour", arrow.get(2013, 5, 5, 0, 0), arrow.get(2013, 5, 5, 19, 0))[::-1]
+    with transaction.manager:
+        posts = fakefactory.PostFactory.create_batch(len(dates_span), public=True)
+        random.shuffle(posts)  # make sure that creation order is not the same as publication order
+        for post, date in zip(posts, dates_span):
+            post.published_at = date.datetime
+        expected_posts_titles = [i.title for i in posts]
+
+    browser.visit(web_server + "/blog/")
+    rendered_posts_titles = [i.text for i in browser.find_by_css(".post h2")]
+
+    assert expected_posts_titles == rendered_posts_titles
+
+
+def test_blog_roll_pagination(web_server: str, browser: DriverAPI, dbsession: Session, fakefactory):
     """When posts exceed batch size, pagination is activated. Test that it's sane."""
 
-    # Direct Splinter browser to the blog showing 5 items per page on page 1
-    b = browser
-    b.visit(web_server + "/blog/?batch_num=0&batch_size=5")
+    posts_per_page = 20
+    with transaction.manager:
+        posts = fakefactory.PostFactory.create_batch(100, public=True)[::-1]
+        dbsession.expunge_all()
 
-    # Iterate 5 times navigating with the 'Next' button
-    for _ in range(5):
-        # After the last 'Next' the button should be disabled
-        if _ == 4:
-            end_of_blog = b.find_by_xpath('//body/main/div[2]/div/div/div//ul/li[3]')
-            # After 10 iterations the next button should be disabled
-            assert end_of_blog.has_class("disabled")
+    browser.visit(web_server + "/blog/")
+    pagination_test(browser, posts, posts_per_page, ".post h2")
 
-        b.find_by_xpath('//body/main/div[2]/div/div/div//ul/li[3]/a').first.click()
+
+def test_user_see_admin_panel_navigation(
+        web_server: str, browser: DriverAPI, dbsession: Session, fakefactory, login_user):
+    """Logged in user sees navigation link to admin panel on blog-roll."""
+
+    with transaction.manager:
+        user = fakefactory.UserFactory(admin=True)
+        dbsession.expunge_all()
+    login_user(user)
+    browser.visit(web_server + "/blog/")
+
+    # admin action menu is present
+    assert browser.is_text_present("Admin actions")
+
+    # after clicking on "Manage posts" user is redirected to posts-listing on admin panel
+    browser.find_by_xpath('//a[text()[contains(.,"Manage posts")]]').click()
+    assert browser.url.endswith('/admin/models/blog-posts/listing')
+
+
+def test_visitor_does_not_see_admin_panel_navigation(
+        web_server: str, browser: DriverAPI, dbsession: Session):
+    """Admin actions are shown to logged in visitors only."""
+
+    browser.visit(web_server + "/blog/")
+    assert not browser.is_text_present("Admin actions")
+
+
+def test_title_and_breadcrumbs(
+        web_server: str, browser: DriverAPI, dbsession: Session):
+    """Checking that breadcrumbs and post-roll title are displayed correctly."""
+
+    blog_title = 'My little Websauna blog'
+
+    browser.visit(web_server + "/blog/")
+    assert browser.find_by_css('h1').text == blog_title
+    assert browser.find_by_css('.breadcrumb').text.endswith(blog_title)

--- a/websauna/blog/tests/functional/test_tag.py
+++ b/websauna/blog/tests/functional/test_tag.py
@@ -1,26 +1,105 @@
 """Functional tests."""
+# Standard Library
+import random
+from uuid import uuid4
+
+# Pyramid
+import transaction
 
 # SQLAlchemy
 from sqlalchemy.orm.session import Session
 
+# Thirdparty Library
+import arrow
 from splinter.driver import DriverAPI
+
+# Websauna
+from websauna.blog.tests.testing import pagination_test
 
 
 def test_empty_tag_roll(web_server: str, browser: DriverAPI, dbsession: Session):
     """We can render empty tag list."""
 
     # Direct Splinter browser to the website
-    b = browser
-    b.visit(web_server + "/blog/tag/xxx")
+    browser.visit(web_server + "/blog/tag/xxx")
 
-    assert b.is_element_present_by_css("#blog-no-posts")
+    assert browser.is_element_present_by_css("#blog-no-posts")
 
 
-def test_tag_roll(web_server: str, browser: DriverAPI, dbsession: Session, published_post_id):
-    """We render tagged posts in their tag roll."""
+def test_visitor_sees_only_relevant_posts_in_tag_roll(
+    web_server: str, browser: DriverAPI, dbsession: Session, fakefactory
+):
+    """Visitors should not see unpublished posts in blog roll."""
 
-    # Direct Splinter browser to the website
-    b = browser
-    b.visit(web_server + "/blog/tag/mytag")
+    with transaction.manager:
+        tag = uuid4().hex
+        post = fakefactory.PostFactory(public=True, tags=tag)
+        fakefactory.PostFactory()
+        dbsession.expunge_all()
 
-    assert b.is_element_present_by_css(".excerpt")
+    browser.visit(web_server + "/blog/tag/{}".format(tag))
+    assert len(browser.find_by_css("div.post")) == 1
+    assert browser.is_text_present(post.title)
+
+
+def test_visitor_sees_only_published_posts_in_tag_roll(
+    web_server: str, browser: DriverAPI, dbsession: Session, fakefactory
+):
+    """Visitors should not see unpublished posts in blog roll."""
+
+    with transaction.manager:
+        tag = uuid4().hex
+        fakefactory.PostFactory(private=True, tags=tag)
+        dbsession.expunge_all()
+
+    browser.visit(web_server + "/blog/tag/{}".format(tag.title))
+    assert browser.is_element_visible_by_css("#blog-no-posts")
+
+
+def test_tag_roll_pagination(web_server: str, browser: DriverAPI, dbsession: Session, fakefactory):
+    """When posts exceed batch size, pagination is activated. Test that it's sane."""
+    posts_per_page = 20
+    with transaction.manager:
+        tag = uuid4().hex
+        posts = fakefactory.PostFactory.create_batch(100, public=True, tags=tag)
+        dbsession.expunge_all()
+
+    browser.visit(web_server + "/blog/tag/{}".format(tag))
+    pagination_test(browser, posts, posts_per_page, ".post h2")
+
+
+def test_posts_are_listed_in_publication_order(
+    web_server: str, browser: DriverAPI, dbsession: Session, fakefactory
+):
+    """Post are listed in publication order on blog-roll."""
+
+    dates_span = arrow.Arrow.range("hour", arrow.get(2013, 5, 5, 0, 0), arrow.get(2013, 5, 5, 19, 0))[::-1]
+    with transaction.manager:
+        tag = uuid4().hex
+        posts = fakefactory.PostFactory.create_batch(len(dates_span), public=True, tags=tag)
+        random.shuffle(posts)  # make sure that creation order is not the same as publication order
+        for post, date in zip(posts, dates_span):
+            post.published_at = date.datetime
+        expected_posts_titles = [i.title for i in posts]
+
+    browser.visit(web_server + "/blog/tag/{}".format(tag))
+
+    rendered_posts_titles = [i.text for i in browser.find_by_css(".post h2")]
+
+    assert expected_posts_titles == rendered_posts_titles
+
+
+def test_title_and_breadcrumbs(
+        web_server: str, browser: DriverAPI, dbsession: Session, fakefactory):
+    """Checking that breadcrumbs and post-roll title are displayed correctly."""
+
+    with transaction.manager:
+        tag = uuid4().hex
+        fakefactory.PostFactory(public=True, tags=tag)
+        dbsession.expunge_all()
+
+    blog_title = 'Posts tagged {}'.format(tag)
+    browser.visit(web_server + "/blog/tag/{}".format(tag))
+
+    assert browser.find_by_css('h1').text == blog_title
+    assert browser.find_by_css('.breadcrumb').text.endswith(blog_title)

--- a/websauna/blog/tests/testing.py
+++ b/websauna/blog/tests/testing.py
@@ -1,0 +1,57 @@
+"""Common testing functions and utilities."""
+
+# Standard Library
+from typing import Iterable
+
+from splinter.driver import DriverAPI
+
+
+def pagination_test(browser: DriverAPI, items: Iterable[object], items_per_page: int, title_selector: str):
+    """Checks if pagination works correctly."""
+
+    def pagination_element(text: str, disabled=False):
+        return browser.find_by_xpath(
+            '//div[@class="pagination-wrapper"]//li[@class="{disabled}"]/a[text()[contains(.,"{text}")]]'.format(
+                text=text, disabled="disabled" if disabled else ""
+            )
+        )
+
+    # checking disabled buttons (First and Previous)
+    assert pagination_element("First", disabled=True)
+    assert pagination_element("Previous", disabled=True)
+
+    # checking not disabled buttons (Next and Last)
+    assert pagination_element("Next")
+    assert pagination_element("Last")
+
+    # navigating to the last page (checking that Last works correctly)
+    pagination_element("Last").click()
+
+    # checking not disabled buttons (First and Previous)
+    assert pagination_element("First")
+    assert pagination_element("Previous")
+
+    # checking disabled buttons (Next and Last)
+    assert pagination_element("Next", disabled=True)
+    assert pagination_element("Last", disabled=True)
+
+    # navigating to the first page (checking that First works correctly)
+    pagination_element("First").click()
+
+    # checking if "next" works correctly
+    posts_titles = set(i.title for i in items)
+    for page in range(0, len(items), items_per_page):
+        rendered_posts_titles = set(i.text for i in browser.find_by_css(title_selector))
+        assert rendered_posts_titles.issubset(posts_titles)
+        posts_titles -= rendered_posts_titles
+        if page < len(items) - items_per_page:
+            pagination_element("Next").click()
+
+    # checking if "prev" works correctly
+    posts_titles = set(i.title for i in items)
+    for page in range(0, len(items), items_per_page):
+        rendered_posts_titles = set(i.text for i in browser.find_by_css(title_selector))
+        assert rendered_posts_titles.issubset(posts_titles)
+        posts_titles -= rendered_posts_titles
+        if page < len(items) - items_per_page:
+            pagination_element("Previous").click()

--- a/websauna/blog/views.py
+++ b/websauna/blog/views.py
@@ -20,7 +20,6 @@ from websauna.system.core.root import Root
 from websauna.system.core.traversal import Resource
 from websauna.system.core.views.redirect import redirect_view
 from websauna.system.crud.paginator import DefaultPaginator
-
 from websauna.system.http import Request
 
 from .models import Post


### PR DESCRIPTION
The scope of changes includes:
* tag-roll pagination bug fix https://github.com/websauna/websauna.blog/commit/9ce19b987a4ed31fbbbe373f5560ab9be3e3e05f
* add [factoryboy](https://factoryboy.readthedocs.io/) factories for creating dummy content for testing
* increase coverage for blog-roll page
* increase coverage for tags-roll page